### PR TITLE
add Doctype

### DIFF
--- a/header.php
+++ b/header.php
@@ -1,3 +1,4 @@
+<!DOCTYPE html>
 <html>
     <head>
         <title><?php wp_title(); ?></title>


### PR DESCRIPTION
A Doctype tells the web browser what type of file this is.

The type of Doctype used above is for HTML 5. The word Doctype is actually case-insensitive so it could be either uppercase or lowercase, doesn't really matter which. I ran with that because copy/paste :+1: 